### PR TITLE
Improve X-Ray integration

### DIFF
--- a/aws/cloudwatch/cloudwatch.go
+++ b/aws/cloudwatch/cloudwatch.go
@@ -1,6 +1,7 @@
 package cloudwatch
 
 import (
+	"context"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -17,7 +18,7 @@ const (
 
 // ClientInterface is an interface of a wrapper of CloudWatch API client
 type ClientInterface interface {
-	PutTemperature(timestamp time.Time, deviceID string, temperature float64) error
+	PutTemperature(ctx context.Context, timestamp time.Time, deviceID string, temperature float64) error
 }
 
 // Client is a wrapper of CloudWatch API client
@@ -33,8 +34,8 @@ func NewClient(api cloudwatchiface.CloudWatchAPI) *Client {
 }
 
 // PutTemperature puts the given room temperature as CloudWatch metric
-func (c *Client) PutTemperature(timestamp time.Time, deviceID string, temperature float64) error {
-	_, err := c.api.PutMetricData(&cloudwatch.PutMetricDataInput{
+func (c *Client) PutTemperature(ctx context.Context, timestamp time.Time, deviceID string, temperature float64) error {
+	_, err := c.api.PutMetricDataWithContext(ctx, &cloudwatch.PutMetricDataInput{
 		Namespace: aws.String(metricNamespace),
 		MetricData: []*cloudwatch.MetricDatum{
 			{

--- a/aws/cloudwatch/cloudwatch_test.go
+++ b/aws/cloudwatch/cloudwatch_test.go
@@ -1,6 +1,7 @@
 package cloudwatch
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -43,8 +44,9 @@ func TestPutTemperature(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
+		ctx := context.Background()
 		cloudwatchMock := mock.NewMockCloudWatchAPI(ctrl)
-		cloudwatchMock.EXPECT().PutMetricData(&cloudwatch.PutMetricDataInput{
+		cloudwatchMock.EXPECT().PutMetricDataWithContext(ctx, &cloudwatch.PutMetricDataInput{
 			Namespace: aws.String("NatureRemo/RoomMetrics"),
 			MetricData: []*cloudwatch.MetricDatum{
 				{
@@ -65,7 +67,7 @@ func TestPutTemperature(t *testing.T) {
 			api: cloudwatchMock,
 		}
 
-		err := client.PutTemperature(tc.timestamp, tc.deviceID, tc.temperature)
+		err := client.PutTemperature(ctx, tc.timestamp, tc.deviceID, tc.temperature)
 		if err != nil {
 			t.Errorf("want no error, got: %s", err)
 		}
@@ -94,8 +96,9 @@ func TestPutTemperature_error(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.subtitle, func(t *testing.T) {
+			ctx := context.Background()
 			cloudwatchMock := mock.NewMockCloudWatchAPI(ctrl)
-			cloudwatchMock.EXPECT().PutMetricData(&cloudwatch.PutMetricDataInput{
+			cloudwatchMock.EXPECT().PutMetricDataWithContext(ctx, &cloudwatch.PutMetricDataInput{
 				Namespace: aws.String("NatureRemo/RoomMetrics"),
 				MetricData: []*cloudwatch.MetricDatum{
 					{
@@ -116,7 +119,7 @@ func TestPutTemperature_error(t *testing.T) {
 				api: cloudwatchMock,
 			}
 
-			err := client.PutTemperature(tc.timestamp, tc.deviceID, tc.temperature)
+			err := client.PutTemperature(ctx, tc.timestamp, tc.deviceID, tc.temperature)
 			if err == nil {
 				t.Fatalf("want error, got nil")
 			}

--- a/aws/ssm/ssm.go
+++ b/aws/ssm/ssm.go
@@ -1,6 +1,8 @@
 package ssm
 
 import (
+	"context"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/aws/aws-sdk-go/service/ssm/ssmiface"
@@ -9,7 +11,7 @@ import (
 
 // ClientInterface is an interface of a wrapper of SSM API client
 type ClientInterface interface {
-	LoadSecret(name string) (string, error)
+	LoadSecret(ctx context.Context, name string) (string, error)
 }
 
 // Client is a wrapper of SSM API client
@@ -25,8 +27,8 @@ func NewClient(api ssmiface.SSMAPI) *Client {
 }
 
 // LoadSecret retrieves decrypted secret from Parameter Store
-func (c *Client) LoadSecret(name string) (string, error) {
-	resp, err := c.api.GetParameter(&ssm.GetParameterInput{
+func (c *Client) LoadSecret(ctx context.Context, name string) (string, error) {
+	resp, err := c.api.GetParameterWithContext(ctx, &ssm.GetParameterInput{
 		Name:           aws.String(name),
 		WithDecryption: aws.Bool(true),
 	})

--- a/aws/ssm/ssm_test.go
+++ b/aws/ssm/ssm_test.go
@@ -1,6 +1,7 @@
 package ssm
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -41,8 +42,9 @@ func TestLoadSecret(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
 			ssmMock := mock.NewMockSSMAPI(ctrl)
-			ssmMock.EXPECT().GetParameter(&ssm.GetParameterInput{
+			ssmMock.EXPECT().GetParameterWithContext(ctx, &ssm.GetParameterInput{
 				Name:           aws.String(tc.name),
 				WithDecryption: aws.Bool(true),
 			}).Return(&ssm.GetParameterOutput{
@@ -56,7 +58,7 @@ func TestLoadSecret(t *testing.T) {
 				api: ssmMock,
 			}
 
-			got, err := client.LoadSecret(tc.name)
+			got, err := client.LoadSecret(ctx, tc.name)
 			if err != nil {
 				t.Fatalf("want no error, got: %s", err)
 			}
@@ -84,8 +86,9 @@ func TestLoadSecret_error(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
 			ssmMock := mock.NewMockSSMAPI(ctrl)
-			ssmMock.EXPECT().GetParameter(&ssm.GetParameterInput{
+			ssmMock.EXPECT().GetParameterWithContext(ctx, &ssm.GetParameterInput{
 				Name:           aws.String(tc.name),
 				WithDecryption: aws.Bool(true),
 			}).Return(nil, fmt.Errorf("unexpected error"))
@@ -94,7 +97,7 @@ func TestLoadSecret_error(t *testing.T) {
 				api: ssmMock,
 			}
 
-			_, err := client.LoadSecret(tc.name)
+			_, err := client.LoadSecret(ctx, tc.name)
 			if err == nil {
 				t.Fatal("want error, got: nil")
 			}

--- a/function/main.go
+++ b/function/main.go
@@ -28,7 +28,7 @@ var (
 )
 
 func Handler(ctx context.Context) error {
-	deviceID, err := SSMClient.LoadSecret(deviceIDKey)
+	deviceID, err := SSMClient.LoadSecret(ctx, deviceIDKey)
 	if err != nil {
 		return errors.Wrap(err, "cannot load device ID")
 	}
@@ -58,7 +58,7 @@ func main() {
 	xray.AWS(ssmapi.Client)
 	SSMClient = ssm.NewClient(ssmapi)
 
-	accessToken, err := SSMClient.LoadSecret(natureRemoAccessTokenKey)
+	accessToken, err := SSMClient.LoadSecret(context.Background(), natureRemoAccessTokenKey)
 	if err != nil {
 		panic(err)
 	}

--- a/function/main.go
+++ b/function/main.go
@@ -46,8 +46,6 @@ func RealHandler(ctx context.Context) error {
 }
 
 func Handler(ctx context.Context) error {
-	xray.Configure(xray.Config{LogLevel: "trace"})
-
 	sess := session.Must(session.NewSession())
 
 	cwapi := cloudwatchapi.New(sess)

--- a/function/main.go
+++ b/function/main.go
@@ -38,7 +38,7 @@ func Handler(ctx context.Context) error {
 		return errors.Wrap(err, "cannot fetch room temperature")
 	}
 
-	if err := CloudWatchClient.PutTemperature(time.Now(), deviceID, temperature); err != nil {
+	if err := CloudWatchClient.PutTemperature(ctx, time.Now(), deviceID, temperature); err != nil {
 		return errors.Wrap(err, "cannot put room temperature")
 	}
 

--- a/function/main.go
+++ b/function/main.go
@@ -28,8 +28,6 @@ var (
 )
 
 func Handler(ctx context.Context) error {
-	xray.Configure(xray.Config{LogLevel: "trace"})
-
 	deviceID, err := SSMClient.LoadSecret(deviceIDKey)
 	if err != nil {
 		return errors.Wrap(err, "cannot load device ID")
@@ -48,7 +46,9 @@ func Handler(ctx context.Context) error {
 }
 
 func main() {
-	sess := session.New()
+	xray.Configure(xray.Config{LogLevel: "trace"})
+
+	sess := session.Must(session.NewSession())
 
 	cwapi := cloudwatchapi.New(sess)
 	xray.AWS(cwapi.Client)

--- a/function/main_test.go
+++ b/function/main_test.go
@@ -24,7 +24,7 @@ type fakeSSMClient struct {
 	Value string
 }
 
-func (c fakeSSMClient) LoadSecret(name string) (string, error) {
+func (c fakeSSMClient) LoadSecret(ctx context.Context, name string) (string, error) {
 	if c.Err != nil {
 		return "", c.Err
 	}

--- a/function/main_test.go
+++ b/function/main_test.go
@@ -11,7 +11,7 @@ type fakeCloudWatchClient struct {
 	Err error
 }
 
-func (c fakeCloudWatchClient) PutTemperature(timestamp time.Time, deviceID string, temperature float64) error {
+func (c fakeCloudWatchClient) PutTemperature(ctx context.Context, timestamp time.Time, deviceID string, temperature float64) error {
 	if c.Err != nil {
 		return c.Err
 	}

--- a/function/main_test.go
+++ b/function/main_test.go
@@ -45,7 +45,7 @@ func (c fakeNatureRemoClient) FetchTemperature(ctx context.Context, deviceID str
 	return c.Temperature, nil
 }
 
-func TestHandler(t *testing.T) {
+func TestRealHandler(t *testing.T) {
 	testcases := []struct {
 		temperature float64
 		value       string
@@ -62,14 +62,14 @@ func TestHandler(t *testing.T) {
 		SSMClient = fakeSSMClient{Value: tc.value}
 		NatureRemoClient = fakeNatureRemoClient{Temperature: tc.temperature}
 
-		err := Handler(ctx)
+		err := RealHandler(ctx)
 		if err != nil {
 			t.Errorf("want no error, got: %s", err)
 		}
 	}
 }
 
-func TestHandler_error(t *testing.T) {
+func TestRealHandler_error(t *testing.T) {
 	testcases := []struct {
 		subtitle      string
 		cloudWatchErr error
@@ -101,7 +101,7 @@ func TestHandler_error(t *testing.T) {
 			SSMClient = fakeSSMClient{Err: tc.ssmErr}
 			NatureRemoClient = fakeNatureRemoClient{Err: tc.natureRemoErr}
 
-			err := Handler(ctx)
+			err := RealHandler(ctx)
 			if err == nil {
 				t.Fatalf("want error, got nil")
 			}


### PR DESCRIPTION
If we want to trace AWS SDK API calls, we have to pass an identical context object to each API calls.

![image](https://user-images.githubusercontent.com/680124/51804506-193eb900-22a5-11e9-9ac0-eb579a0fed7e.png)


## REF

[Tracing AWS SDK Calls with the X-Ray SDK for Go - AWS X-Ray](https://docs.aws.amazon.com/xray/latest/devguide/xray-sdk-go-awssdkclients.html)