### PR TITLE
Make it able to trace Nature Remo API call

### DIFF
--- a/function/main.go
+++ b/function/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"net/http"
 	"time"
 
 	"github.com/dtan4/nature-remo-to-cloud-watch-function/aws/cloudwatch"
@@ -61,7 +62,7 @@ func Handler(ctx context.Context) error {
 		return errors.Wrap(err, "cannot load Nature Remo access token")
 	}
 
-	NatureRemoClient = natureremo.NewClient(accessToken)
+	NatureRemoClient = natureremo.NewClient(accessToken, xray.Client(http.DefaultClient))
 
 	return RealHandler(ctx)
 }

--- a/natureremo/natureremo.go
+++ b/natureremo/natureremo.go
@@ -2,6 +2,7 @@ package natureremo
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/pkg/errors"
 	natureremoapi "github.com/tenntenn/natureremo"
@@ -18,9 +19,15 @@ type Client struct {
 }
 
 // NewClient creates new Client object with a configured API client
-func NewClient(accessToken string) *Client {
+func NewClient(accessToken string, httpClient *http.Client) *Client {
+	api := natureremoapi.NewClient(accessToken)
+
+	if httpClient != nil {
+		api.HTTPClient = httpClient
+	}
+
 	return &Client{
-		api: natureremoapi.NewClient(accessToken),
+		api: api,
 	}
 }
 

--- a/natureremo/natureremo_test.go
+++ b/natureremo/natureremo_test.go
@@ -3,6 +3,7 @@ package natureremo
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"testing"
 
 	natureremoapi "github.com/tenntenn/natureremo"
@@ -40,17 +41,24 @@ func (f fakeDeviceService) UpdateHumidityOffset(ctx context.Context, device *nat
 func TestNewClient(t *testing.T) {
 	testcases := []struct {
 		accessToken string
+		httpClient  *http.Client
 	}{
 		{
 			accessToken: "",
+			httpClient:  nil,
+		},
+		{
+			accessToken: "",
+			httpClient:  http.DefaultClient,
 		},
 		{
 			accessToken: "dummyaccesstoken",
+			httpClient:  nil,
 		},
 	}
 
 	for _, tc := range testcases {
-		got := NewClient(tc.accessToken)
+		got := NewClient(tc.accessToken, tc.httpClient)
 		if got == nil {
 			t.Error("want client, got nil")
 		}


### PR DESCRIPTION
Trace Nature Remo API call by using X-Ray-wrapped HTTP client

![image](https://user-images.githubusercontent.com/680124/51804708-92d7a680-22a7-11e9-9d4d-244b11ea0bce.png)


## REF

[Instrumenting Go Code in AWS Lambda - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/go-tracing.html#go-tracing-use-client-method)