### PR TITLE
Run test on local

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: go
-services:
-  - docker
 
 go:
   - '1.12.x'
@@ -11,9 +9,6 @@ env:
 branches:
   only:
     - master
-
-install:
-  - make setup-go
 
 script:
   - make test

--- a/Makefile
+++ b/Makefile
@@ -34,4 +34,4 @@ setup-sam:
 
 .PHONY: test
 test:
-	docker-compose run --rm go test -coverprofile=coverage.txt -v `docker-compose run -T --rm go list ./... | grep -v aws/mock`
+	go test -coverpkg=./... -coverprofile=coverage.txt -v ./...


### PR DESCRIPTION
Since we removed gomock in #15 , we don't need Docker environment for CI anymore.

For CD, we still need to ensure the binary is for Linux amd64. So I leave Docker environment for Go for now.